### PR TITLE
PYD-013 feat: add metadata about unused imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## Added
+- CHANGELOG to track notable changes
+- add metadata about unused imports in the concrete implementations (`AbsoluteImportStatement`, `RelativeImportStatement`, `ImportFromStatement`)
+
+
+## [1.0.0] - 13 Nov 2021
+
+### Added
+
+- add collector object `ImportsCollectionFile` to abstract the information about imports in the file
+- add `AbsoluteImportStatement`, `RelativeImportStatement`, `ImportFromStatement` concrete classes to describe each of the import types
+- add `AstImportAnalyzer` to traverse the abstract syntax tree python code
+- context manager `PyImports` to introspect imports in a file|dir 

--- a/examples/introspect_myself.py
+++ b/examples/introspect_myself.py
@@ -10,7 +10,7 @@ with PyImports() as manager:
     imports = manager.imports_resume()
 
 
-# Now yo have access to the import used in each file
+# Now yuo have access to the import used in each file
 print(imports)
 
 # Get details about the absolute, relative and standard import in the file
@@ -19,7 +19,7 @@ absolute_imports = collector_object.absolute_imports
 relative_imports = collector_object.relative_imports
 imports = collector_object.imports
 
-# It's obvious that in this file, theare just one absolute import
+# It's obvious that in this file, there are just one absolute import
 # from py_imports.manager import PyImports
-# If we introspect the object, wi will get the next
+# If we introspect the object, we will get the next
 print(absolute_imports[0])

--- a/py_imports/base/models.py
+++ b/py_imports/base/models.py
@@ -24,9 +24,7 @@ class ImportStatement:
         self.children = children
         self.statement = statement
 
-        self.from_internal: bool = False
-        self.children_unused: List = []
-        self.kwargs = kwargs
+        self.children_unused: List = kwargs.get("children_unused", [])
 
 
 class ImportFromStatement(ImportStatement):

--- a/py_imports/manager.py
+++ b/py_imports/manager.py
@@ -5,6 +5,8 @@ import os
 from types import TracebackType
 from typing import Dict, List, NoReturn, Optional, Type, TypeVar, Union, cast
 
+from typing_extensions import Literal
+
 from py_imports.ast_analyzers import AstImportAnalyzer
 from py_imports.base.models import ImportsCollectionFile
 from py_imports.exceptions import WrongFileExtension
@@ -46,8 +48,8 @@ class PyImports(UnUsedImportMixin):
         exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
-    ) -> bool:
-        return True
+    ) -> Literal[False]:
+        return False
 
     @staticmethod
     def is_valid(path: str) -> Union[NoReturn, bool]:
@@ -68,10 +70,11 @@ class PyImports(UnUsedImportMixin):
             path_file: absolute path file to parse
         """
         with open(path_file, "r", encoding="utf-8") as file:
-            data = file.readlines()
+            file_content = file.readlines()
             file.seek(0)
-            analyzer = AstImportAnalyzer(data)
-            tree = ast.parse(file.read())
+            raw_content = file.read()
+            analyzer = AstImportAnalyzer(file_content, raw_content)
+            tree = ast.parse(raw_content)
             analyzer.visit(tree)
 
         return analyzer.imports_metadata

--- a/tests/test_integration/test_ast_analyzer.py
+++ b/tests/test_integration/test_ast_analyzer.py
@@ -33,8 +33,9 @@ class TestAstImportAnalyzer:
         with open(file_path, "r", encoding="utf8") as file:
             data = file.readlines()
             file.seek(0)
-            analyzer = self.ast_analyzer(data)
-            tree = ast.parse(file.read())
+            raw_content = file.read()
+            analyzer = self.ast_analyzer(data, raw_content)
+            tree = ast.parse(raw_content)
             analyzer.visit(tree)
 
         imports = analyzer.imports_metadata

--- a/tests/test_integration/test_py_imports.py
+++ b/tests/test_integration/test_py_imports.py
@@ -190,4 +190,4 @@ class TestPyImports:
             import_unused_found = imports.absolute_imports[0].children_unused
 
             assert len(import_unused_found) == 2
-            assert import_unused_found == ["django", "django"]
+            assert import_unused_found == ["django", "foo"]

--- a/tests/test_unit/test_mixins.py
+++ b/tests/test_unit/test_mixins.py
@@ -1,7 +1,5 @@
 """Unit test cases to validate mixins"""
 
-from typing import Callable
-
 from py_imports.mixins import UnUsedImportMixin
 
 
@@ -15,11 +13,13 @@ class TestUnUsedImportMixin:
     Test cases to validate the UnUsedImportMixin
     """
 
-    mixin = UnUsedImportMixin
+    class TestCase(UnUsedImportMixin):
+        """test class"""
 
-    def test_if_it_returned_the_unused_import_from_file(
-        self, set_up_file: Callable
-    ) -> None:
+        def __init__(self, raw_content: str) -> None:
+            self.raw_content = raw_content
+
+    def test_if_it_returned_the_unused_import_from_file(self) -> None:
         """
         Validate if the unused import are properly detected
 
@@ -30,10 +30,11 @@ class TestUnUsedImportMixin:
                 function_one()
 
         Expected result:
-            * request from flask was not used in the file
+            * In the line 1, request from flask was not used in the file
         """
-        file_path = set_up_file(
-            """from flask import request\nfrom module import foo\nfoo()"""
-        )
-        unused_imports = UnUsedImportMixin.get_unused_import(file_path)
-        assert unused_imports[0] == "flask.request"
+
+        raw_content = """from flask import request\nfrom module import foo\nfoo()"""
+
+        test_instance = self.TestCase(raw_content)
+        unused_imports = test_instance.get_unused_import()
+        assert unused_imports[1] == ["request"]


### PR DESCRIPTION
changes:

- fix some type in examples/
- remove `from_internal` from the concrete implementation to avoid ambiguity (this feature could be added un the future)
- add CHANGELOG support