### PR TITLE
fix: prepare release with latest changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 14 Nov 2021
 
 ## Added
 - CHANGELOG to track notable changes
 - add metadata about unused imports in the concrete implementations (`AbsoluteImportStatement`, `RelativeImportStatement`, `ImportFromStatement`)
 
+## Fixed
+- avoid silencing exceptions in `PyImports` context manager
 
 ## [1.0.0] - 13 Nov 2021
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ first_import.line -> 1
 
 # Now you know more about you...
 ```
+## Notes
 
+This library does not execute any part of the python  target code, this just make a static analysis over the code to describe the meta information about the imports in the file.
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/py_imports/base/models.py
+++ b/py_imports/base/models.py
@@ -24,7 +24,9 @@ class ImportStatement:
         self.children = children
         self.statement = statement
 
+        self.from_internal: bool = False
         self.children_unused: List = kwargs.get("children_unused", [])
+        self.kwargs = kwargs
 
 
 class ImportFromStatement(ImportStatement):


### PR DESCRIPTION
changes:

- avoid breaking the public api
- avoid silencing exceptions in `PyImports` context manage