### PR TITLE
PYD-019 feat: detect imports in inner scopes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -564,7 +564,7 @@ valid-metaclass-classmethod-first-arg=cls
 max-args=6
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=12
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The possibility to know if the imports is located inside a function, class or other python structure definition
+- Attributes `outer_parent_node`, `in_inner_scope` in every concrete class (`AbsoluteImportStatement`, `RelativeImportStatement`, `ImportFromStatement`)
+
+## [Released]
+
 ## [1.1.0] - 14 Nov 2021
 
 ### Added

--- a/py_imports/ast_analyzers.py
+++ b/py_imports/ast_analyzers.py
@@ -1,16 +1,9 @@
 """ast classes to parse py files"""
 import ast
-from typing import Any, List, Protocol, cast, runtime_checkable
+from typing import Any, List
 
 from py_imports.base import ImportsCollectionFile
 from py_imports.mixins import UnUsedImportMixin
-
-
-@runtime_checkable
-class ParentProto(Protocol):
-    """Annotated AST with extra attributes"""
-
-    parent: ast.AST
 
 
 class AstImportAnalyzer(UnUsedImportMixin, ast.NodeVisitor):
@@ -51,8 +44,8 @@ class AstImportAnalyzer(UnUsedImportMixin, ast.NodeVisitor):
         """
         imports: List[str] = [pkg_name.name for pkg_name in node.names]
 
-        outer_parent_import = cast(ParentProto, node).parent
-        is_in_outer_import = not isinstance(cast(ParentProto, node).parent, ast.Module)
+        outer_parent_import = node.parent  # type: ignore
+        is_in_outer_import = not isinstance(outer_parent_import, ast.Module)
 
         self._imports_collector.register_import(
             line=node.lineno,
@@ -80,8 +73,8 @@ class AstImportAnalyzer(UnUsedImportMixin, ast.NodeVisitor):
         """
         imports: List[str] = [alias.name for alias in node.names]
 
-        outer_parent_import = cast(ParentProto, node).parent
-        is_in_outer_import = not isinstance(cast(ParentProto, node).parent, ast.Module)
+        outer_parent_import = node.parent  # type: ignore
+        is_in_outer_import = not isinstance(outer_parent_import, ast.Module)
 
         self._imports_collector.register_import_from(
             line=node.lineno,

--- a/py_imports/base/models.py
+++ b/py_imports/base/models.py
@@ -25,7 +25,10 @@ class ImportStatement:
         self.statement = statement
 
         self.from_internal: bool = False
-        self.children_unused: List = kwargs.get("children_unused", [])
+        self.children_unused: List = kwargs.pop("children_unused", [])
+        self.outer_parent_node: Any = kwargs.pop("outer_parent_node", None)
+        self.in_inner_scope: bool = bool(self.outer_parent_node)
+
         self.kwargs = kwargs
 
 


### PR DESCRIPTION
changes:
- The possibility to know if the imports is located inside a function, class or other python structure definition
- Attributes `outer_parent_node`, `in_inner_scope` in every concrete class (`AbsoluteImportStatement`, `RelativeImportStatement`, `ImportFromStatement`)